### PR TITLE
Make category field case-insensitive in partial update

### DIFF
--- a/src/main/java/com/swipeurstyle/jwt/backend/controller/GarmentController.java
+++ b/src/main/java/com/swipeurstyle/jwt/backend/controller/GarmentController.java
@@ -181,7 +181,7 @@ public class GarmentController {
                         break;
                     case "category":
                         GarmentCategory garmentCategory;
-                        switch ((String) value) {
+                        switch (((String) value).toUpperCase()) {
                             case "TOP":
                                 garmentCategory = GarmentCategory.TOP;
                                 break;


### PR DESCRIPTION
- Convert the category value to uppercase before comparison
- Ensure the category can be updated with any case combination (e.g., Top, TOP, top, etc.)